### PR TITLE
Remove `-o pipefail`, for dash shell compatibility

### DIFF
--- a/git-credentials-helper/README.md
+++ b/git-credentials-helper/README.md
@@ -13,7 +13,8 @@ can use this helper like:
     steps:
       - name: node:16
         script: |
-          set -o errexit -o nounset -o pipefail
+          set -o errexit -o nounset
+          # And `set -o pipefail` when using bash.
           git config --system credential.helper /workspace/githelper.py
           npm ci
 


### PR DESCRIPTION
Images based on Debian and Ubuntu use dash as the default interpreter. Dash exits with an illegal option error if you do `set -o pipefail`.